### PR TITLE
Fix Dockerfile regtest port

### DIFF
--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -69,6 +69,6 @@ COPY docker-entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 
-EXPOSE 9998 9999 19998 19999
+EXPOSE 9998 9999 18332 19998 19999
 
 CMD ["dashd"]


### PR DESCRIPTION
This PR fixes the exposed RPC port for the Dash regression test, adding the port `18332`. See [here](https://github.com/dashpay/dash/blob/master/src/chainparamsbase.cpp#L62).