### PR TITLE
Switch to multi-stage builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ after_script:
 
 before_script:
   - cd "$VERSION"
-  - IMAGE="dashd:${VERSION/\//-}"
+  - IMAGE="dash-core:${VERSION/\//-}"
 
 env:
   - VERSION=0.12
+  - VERSION=0.12/alpine
 
 language: bash
 

--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -1,67 +1,43 @@
-FROM alpine:3.6
+FROM debian:stable-slim
 
-MAINTAINER Pedro Branco <branco@uphold.com> (@pedrobranco)
+LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
+  maintainer.1="Pedro Branco (@pedrobranco)" \
+  maintainer.2="Rui Marinho (@ruimarinho)"
 
-RUN adduser -S dash
+RUN useradd -r dash \
+  && apt-get update -y \
+  && apt-get install -y curl gnupg unzip \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && set -ex \
+  && for key in \
+    B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    4B88269ABD8DF332 \
+  ; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
+    gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
+  done
 
-ENV BERKELEYDB_VERSION=db-4.8.30.NC
-ENV BERKELEYDB_PREFIX=/opt/${BERKELEYDB_VERSION}
+ENV GOSU_VERSION=1.10
+
+RUN curl -o /usr/local/bin/gosu -fSL https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture) \
+  && curl -o /usr/local/bin/gosu.asc -fSL https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture).asc \
+  && gpg --verify /usr/local/bin/gosu.asc \
+  && rm /usr/local/bin/gosu.asc \
+  && chmod +x /usr/local/bin/gosu
 
 ENV DASH_VERSION=0.12.2.2
-ENV DASH_PREFIX=/opt/dash-${DASH_VERSION}
-ENV DASH_DATA=/home/dash/.dashcore
-ENV PATH=${DASH_PREFIX}/bin:$PATH
-
-RUN apk --no-cache --virtual build-dependendencies add autoconf \
-    automake \
-    boost-dev \
-    build-base \
-    chrpath \
-    file \
-    gnupg \
-    libevent-dev \
-    libressl \
-    libressl-dev \
-    libtool \
-    linux-headers \
-    protobuf-dev \
-    zeromq-dev \
-  && mkdir -p /tmp/build \
-  && mkdir -p /tmp/build/${DASH_VERSION} \
-  && wget -O /tmp/build/${BERKELEYDB_VERSION}.tar.gz http://download.oracle.com/berkeley-db/${BERKELEYDB_VERSION}.tar.gz \
-  && tar -xzf /tmp/build/${BERKELEYDB_VERSION}.tar.gz -C /tmp/build/ \
-  && sed s/__atomic_compare_exchange/__atomic_compare_exchange_db/g -i /tmp/build/${BERKELEYDB_VERSION}/dbinc/atomic.h \
-  && mkdir -p ${BERKELEYDB_PREFIX} \
-  && cd /tmp/build/${BERKELEYDB_VERSION}/build_unix \
-  && ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=${BERKELEYDB_PREFIX} \
-  && make install \
-  && wget -P /tmp/build/${DASH_VERSION} https://github.com/dashpay/dash/archive/v${DASH_VERSION}.tar.gz \
-  && echo "fd5f1576bc8ef70e5823f665b86a334937813e300f037a03bcd127b83773d771  /tmp/build/${DASH_VERSION}/v${DASH_VERSION}.tar.gz" | sha256sum -c \
-  && cd /tmp/build/${DASH_VERSION} \
-  && tar -xzf v${DASH_VERSION}.tar.gz -C /tmp/build \
-  && cd /tmp/build/dash-${DASH_VERSION} \
-  && ./autogen.sh \
-  && ./configure LDFLAGS=-L${BERKELEYDB_PREFIX}/lib/ CPPFLAGS=-I${BERKELEYDB_PREFIX}/include/ \
-    --prefix=${DASH_PREFIX} \
-    --mandir=/usr/share/man \
-    --disable-tests \
-    --disable-bench \
-    --disable-ccache \
-    --with-gui=no \
-    --with-utils \
-    --with-libs \
-    --with-daemon \
-  && make install \
-  && cd / \
-  && strip ${DASH_PREFIX}/bin/dash-cli ${DASH_PREFIX}/bin/dashd ${DASH_PREFIX}/bin/dash-tx ${DASH_PREFIX}/lib/libdashconsensus.a ${DASH_PREFIX}/lib/libdashconsensus.so.0.0.0 \
-  && rm -rf /tmp/build ${BERKELEYDB_PREFIX}/docs \
-  && apk --no-cache --purge del build-dependendencies \
-  && apk --no-cache add boost \
-    boost-program_options \
-    libevent \
-    libressl \
-    libzmq \
-    su-exec
+ENV DASH_FOLDER_VERSION=0.12.2
+ENV DASH_DATA=/home/dash/.dashcore \
+  PATH=/opt/dashcore-${DASH_FOLDER_VERSION}/bin:$PATH
+RUN curl -SLO https://github.com/dashpay/dash/releases/download/v${DASH_VERSION}/SHA256SUMS.asc \
+  && curl -SLO https://github.com/dashpay/dash/releases/download/v${DASH_VERSION}/dashcore-${DASH_VERSION}-linux64.tar.gz \
+  && curl -SLO https://github.com/dashpay/dash/releases/download/v${DASH_VERSION}/dashcore-${DASH_VERSION}-linux64.tar.gz.asc \
+  && gpg --verify dashcore-${DASH_VERSION}-linux64.tar.gz.asc \
+  && tar -xzf dashcore-${DASH_VERSION}-linux64.tar.gz -C /opt \
+  && rm *.tar.gz
 
 VOLUME ["/home/dash/.dashcore"]
 

--- a/0.12/alpine/Dockerfile
+++ b/0.12/alpine/Dockerfile
@@ -1,0 +1,119 @@
+# Build stage for BerkeleyDB
+FROM alpine as berkeleydb
+
+RUN apk --no-cache add autoconf
+RUN apk --no-cache add automake
+RUN apk --no-cache add build-base
+RUN apk --no-cache add libressl
+
+ENV BERKELEYDB_VERSION=db-4.8.30.NC
+ENV BERKELEYDB_PREFIX=/opt/${BERKELEYDB_VERSION}
+
+RUN wget https://download.oracle.com/berkeley-db/${BERKELEYDB_VERSION}.tar.gz
+RUN tar -xzf *.tar.gz
+RUN sed s/__atomic_compare_exchange/__atomic_compare_exchange_db/g -i ${BERKELEYDB_VERSION}/dbinc/atomic.h
+RUN mkdir -p ${BERKELEYDB_PREFIX}
+
+WORKDIR /${BERKELEYDB_VERSION}/build_unix
+
+RUN ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=${BERKELEYDB_PREFIX}
+RUN make -j4
+RUN make install
+RUN rm -rf ${BERKELEYDB_PREFIX}/docs
+
+# Build stage for Dash
+FROM alpine as dash
+
+COPY --from=berkeleydb /opt /opt
+
+RUN apk --no-cache add autoconf
+RUN apk --no-cache add automake
+RUN apk --no-cache add boost-dev
+RUN apk --no-cache add build-base
+RUN apk --no-cache add chrpath
+RUN apk --no-cache add file
+RUN apk --no-cache add gnupg
+RUN apk --no-cache add libevent-dev
+RUN apk --no-cache add libressl
+RUN apk --no-cache add libressl-dev
+RUN apk --no-cache add libsodium-dev
+RUN apk --no-cache add libtool
+RUN apk --no-cache add linux-headers
+RUN apk --no-cache add protobuf-dev
+RUN apk --no-cache add zeromq-dev
+
+RUN set -ex \
+  && for key in \
+    38EE12EB597B4FC0 \
+  ; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
+    gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
+  done
+
+ENV DASH_VERSION=0.12.2.2
+ENV DASH_PREFIX=/opt/dash-${DASH_VERSION}
+ENV DASH_SHASUM="fd5f1576bc8ef70e5823f665b86a334937813e300f037a03bcd127b83773d771  v${DASH_VERSION}.tar.gz"
+
+RUN wget https://github.com/dashpay/dash/archive/v${DASH_VERSION}.tar.gz
+RUN echo "${DASH_SHASUM}" | sha256sum -c
+RUN tar -xzf *.tar.gz
+RUN ls -la
+
+WORKDIR /dash-${DASH_VERSION}
+
+RUN sed -i '/AC_PREREQ/a\AR_FLAGS=cr' src/univalue/configure.ac
+RUN sed -i '/AX_PROG_CC_FOR_BUILD/a\AR_FLAGS=cr' src/secp256k1/configure.ac
+RUN sed -i s:sys/fcntl.h:fcntl.h: src/compat.h
+RUN ./autogen.sh
+RUN ./configure LDFLAGS=-L`ls -d /opt/db*`/lib/ CPPFLAGS=-I`ls -d /opt/db*`/include/ \
+  --prefix=${DASH_PREFIX} \
+  --mandir=/usr/share/man \
+  --disable-tests \
+  --disable-bench \
+  --disable-ccache \
+  --with-gui=no \
+  --with-utils \
+  --with-libs \
+  --with-daemon
+RUN make -j4
+RUN make install
+RUN strip ${DASH_PREFIX}/bin/dash-cli
+RUN strip ${DASH_PREFIX}/bin/dash-tx
+RUN strip ${DASH_PREFIX}/bin/dashd
+RUN strip ${DASH_PREFIX}/lib/libdashconsensus.a
+RUN strip ${DASH_PREFIX}/lib/libdashconsensus.so.0.0.0
+
+# Build stage for compiled artifacts
+FROM alpine
+
+LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
+  maintainer.1="Pedro Branco (@pedrobranco)" \
+  maintainer.2="Rui Marinho (@ruimarinho)"
+
+RUN adduser -S dash
+RUN apk --no-cache add \
+  boost \
+  boost-program_options \
+  curl \
+  libevent \
+  libressl \
+  libzmq \
+  su-exec
+
+ENV DASH_DATA=/home/dash/.dashcore
+ENV DASH_VERSION=0.12.2.2
+ENV DASH_PREFIX=/opt/dash-${DASH_VERSION}
+ENV PATH=${DASH_PREFIX}/bin:$PATH
+
+COPY --from=dash /opt /opt
+COPY docker-entrypoint.sh /entrypoint.sh
+
+VOLUME ["/home/dash/.dashcore"]
+
+EXPOSE 9998 9999 18332 19998 19999
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["dashd"]

--- a/0.12/alpine/docker-entrypoint.sh
+++ b/0.12/alpine/docker-entrypoint.sh
@@ -19,7 +19,7 @@ fi
 
 if [ "$1" = "dashd" ] || [ "$1" = "dash-cli" ] || [ "$1" = "dash-tx" ]; then
   echo
-  exec gosu dash "$@"
+  exec su-exec dash "$@"
 fi
 
 echo

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # uphold/docker-dash-core
+
 A Dash Core docker image.
 
 [![uphold/dash-core][docker-pulls-image]][docker-hub-url] [![uphold/dash-core][docker-stars-image]][docker-hub-url] [![uphold/dash-core][docker-size-image]][docker-hub-url] [![uphold/dash-core][docker-layers-image]][docker-hub-url]
 
-## Supported tags and respective `Dockerfile` links
+## Tags
 
-- `0.12.2.2`, `0.12`, `latest` ([0.12/Dockerfile](https://github.com/uphold/dash-core/blob/master/0.12/Dockerfile))
+- `0.12.2.2-alpine`, `0.12-alpine`, `alpine`, `latest` ([0.15/alpine/Dockerfile](https://github.com/uphold/docker-dash-core/blob/master/0.12/alpine/Dockerfile))
+- `0.12.2.2`, `0.12`  ([0.15/Dockerfile](https://github.com/uphold/docker-dash-core/blob/master/0.12/Dockerfile))
 
 ## What is Dash?
 _from [dashwiki](https://github.com/dashpay/dash/wiki)_
@@ -13,7 +15,9 @@ _from [dashwiki](https://github.com/dashpay/dash/wiki)_
 Dash: A Privacy-Centric Crypto-Currency https://www.dash.org
 
 ## Usage
+
 ### How to use this image
+
 This image contains the main binaries from the Dash Core project - `dashd`, `dash-cli` and `dash-tx`. It behaves like a binary, so you can pass any arguments to the image and they will be forwarded to the `dashd` binary:
 
 ```sh
@@ -148,21 +152,26 @@ Done!
 
 
 ## Image variants
+
 The `uphold/dash-core` image comes in multiple flavors:
 
 ### `uphold/dash-core:latest`
+
 Points to the latest release available of Dash Core. Occasionally pre-release versions will be included.
 
 ### `uphold/dash-core:<version>`
+
 Based on Alpine Linux with Berkeley DB 4.8 (cross-compatible build), targets a specific version branch or release of Dash Core.
 
 ## Supported Docker versions
+
 This image is officially supported on Docker version 1.12, with support for older versions provided on a best-effort basis.
 
 ## License
+
 [License information](https://github.com/dashpay/dash/blob/master/COPYING) for the software contained in this image.
 
-[License information](https://github.com/uphold/dash-core/blob/master/LICENSE) for the [uphold/dash-core](https://hub.docker.com/r/uphold/dash-core) docker project.
+[License information](https://github.com/uphold/docker-dash-core/blob/master/LICENSE) for the [uphold/dash-core][docker-hub-url] docker project.
 
 [docker-hub-url]: https://hub.docker.com/r/uphold/dash-core
 [docker-layers-image]: https://img.shields.io/imagelayers/layers/uphold/dash-core/latest.svg?style=flat-square


### PR DESCRIPTION
**Alpine-based image**

* Uses multi-stage builds to improve developer experience and reduce image size.
* Takes advantage of Docker cache mechanisms by improving order of directives.
* Uses parallel build jobs for considerable compile speed-up.
* Fix some compilation warnings.

**Debian-based image**

* Add new debian-based image using official binaries.