### PR TITLE
Add support for DASH 0.12.2.3

### DIFF
--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -o /usr/local/bin/gosu -fSL https://github.com/tianon/gosu/releases/dow
   && rm /usr/local/bin/gosu.asc \
   && chmod +x /usr/local/bin/gosu
 
-ENV DASH_VERSION=0.12.2.2
+ENV DASH_VERSION=0.12.2.3
 ENV DASH_FOLDER_VERSION=0.12.2
 ENV DASH_DATA=/home/dash/.dashcore \
   PATH=/opt/dashcore-${DASH_FOLDER_VERSION}/bin:$PATH

--- a/0.12/alpine/Dockerfile
+++ b/0.12/alpine/Dockerfile
@@ -52,9 +52,9 @@ RUN set -ex \
     gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
   done
 
-ENV DASH_VERSION=0.12.2.2
+ENV DASH_VERSION=0.12.2.3
 ENV DASH_PREFIX=/opt/dash-${DASH_VERSION}
-ENV DASH_SHASUM="fd5f1576bc8ef70e5823f665b86a334937813e300f037a03bcd127b83773d771  v${DASH_VERSION}.tar.gz"
+ENV DASH_SHASUM="5347351483ce39d1dd0be4d93ee19aba1a6b02bc7f90948b4eea4466ad79d1c3  v${DASH_VERSION}.tar.gz"
 
 RUN wget https://github.com/dashpay/dash/archive/v${DASH_VERSION}.tar.gz
 RUN echo "${DASH_SHASUM}" | sha256sum -c
@@ -103,7 +103,7 @@ RUN apk --no-cache add \
   su-exec
 
 ENV DASH_DATA=/home/dash/.dashcore
-ENV DASH_VERSION=0.12.2.2
+ENV DASH_VERSION=0.12.2.3
 ENV DASH_PREFIX=/opt/dash-${DASH_VERSION}
 ENV PATH=${DASH_PREFIX}/bin:$PATH
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A Dash Core docker image.
 
 ## Tags
 
-- `0.12.2.2-alpine`, `0.12-alpine`, `alpine`, `latest` ([0.15/alpine/Dockerfile](https://github.com/uphold/docker-dash-core/blob/master/0.12/alpine/Dockerfile))
-- `0.12.2.2`, `0.12`  ([0.15/Dockerfile](https://github.com/uphold/docker-dash-core/blob/master/0.12/Dockerfile))
+- `0.12.2.3-alpine`, `0.12-alpine`, `alpine`, `latest` ([0.12/alpine/Dockerfile](https://github.com/uphold/docker-dash-core/blob/master/0.12/alpine/Dockerfile))
+- `0.12.2.3`, `0.12`  ([0.12/Dockerfile](https://github.com/uphold/docker-dash-core/blob/master/0.12/Dockerfile))
 
 ## What is Dash?
 _from [dashwiki](https://github.com/dashpay/dash/wiki)_


### PR DESCRIPTION
This PR adds support for the DASH Core latest version: 0.12.2.3.

