### PR TITLE
Fix regtest RPC port for 0.15 and 0.16 images

### DIFF
--- a/0.15/Dockerfile
+++ b/0.15/Dockerfile
@@ -46,6 +46,6 @@ COPY docker-entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 
-EXPOSE 9998 9999 19998 19999
+EXPOSE 9998 9999 19898 19998 19999
 
 CMD ["dashd"]

--- a/0.16/Dockerfile
+++ b/0.16/Dockerfile
@@ -45,6 +45,6 @@ COPY docker-entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 
-EXPOSE 9998 9999 19998 19999
+EXPOSE 9998 9999 19898 19998 19999
 
 CMD ["dashd"]


### PR DESCRIPTION
Fix the regtest RPC port changed, from the inherited bitcoin `18332` to `19898`, which changed on version `0.15`, as one can see [here](https://github.com/dashpay/dash/blob/v0.15.x/src/chainparamsbase.cpp#L75) and [here](https://github.com/dashpay/dash/blob/v0.16.x/src/chainparamsbase.cpp#L76). 