### PR TITLE
Add Dash Core 0.17.0.3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         version:
+          - '0.17'
           - '0.16'
           - '0.15'
           - '0.14'

--- a/0.17/Dockerfile
+++ b/0.17/Dockerfile
@@ -1,0 +1,50 @@
+FROM debian:stable-slim
+
+LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
+  maintainer.1="Pedro Branco (@pedrobranco)" \
+  maintainer.2="Rui Marinho (@ruimarinho)"
+
+RUN useradd -r dash \
+  && apt-get update -y \
+  && apt-get install -y curl gnupg unzip \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && set -ex \
+  && for key in \
+    B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    29590362EC878A81FD3C202B52527BEDABE87984 \
+  ; do \
+    gpg --keyserver keyserver.ubuntu.com --recv-keys "$key" || \
+    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
+    gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
+    gpg --keyserver keys.openpgp.org --recv-keys "$key" ; \
+  done
+
+ENV GOSU_VERSION=1.10
+
+RUN curl -o /usr/local/bin/gosu -fSL https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture) \
+  && curl -o /usr/local/bin/gosu.asc -fSL https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture).asc \
+  && gpg --verify /usr/local/bin/gosu.asc \
+  && rm /usr/local/bin/gosu.asc \
+  && chmod +x /usr/local/bin/gosu
+
+ENV DASH_VERSION=0.17.0.3
+ENV DASH_FOLDER_VERSION=0.17.0
+ENV DASH_DATA=/home/dash/.dashcore \
+  PATH=/opt/dashcore-${DASH_FOLDER_VERSION}/bin:$PATH
+RUN curl -SLO https://github.com/dashpay/dash/releases/download/v${DASH_VERSION}/SHA256SUMS.asc \
+  && curl -SLO https://github.com/dashpay/dash/releases/download/v${DASH_VERSION}/dashcore-${DASH_VERSION}-x86_64-linux-gnu.tar.gz \
+  && curl -SLO https://github.com/dashpay/dash/releases/download/v${DASH_VERSION}/dashcore-${DASH_VERSION}-x86_64-linux-gnu.tar.gz.asc \
+  && gpg --verify dashcore-${DASH_VERSION}-x86_64-linux-gnu.tar.gz.asc \
+  && tar -xzf dashcore-${DASH_VERSION}-x86_64-linux-gnu.tar.gz -C /opt \
+  && rm *.tar.gz
+
+VOLUME ["/home/dash/.dashcore"]
+
+COPY docker-entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 9998 9999 19898 19998 19999
+
+CMD ["dashd"]

--- a/0.17/docker-entrypoint.sh
+++ b/0.17/docker-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+
+if [ $(echo "$1" | cut -c1) = "-" ]; then
+  echo "$0: assuming arguments for dashd"
+
+  set -- dashd "$@"
+fi
+
+if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "dashd" ]; then
+  mkdir -p "$DASH_DATA"
+  chmod 700 "$DASH_DATA"
+  chown -R dash "$DASH_DATA"
+
+  echo "$0: setting data directory to $DASH_DATA"
+
+  set -- "$@" -datadir="$DASH_DATA"
+fi
+
+if [ "$1" = "dashd" ] || [ "$1" = "dash-cli" ] || [ "$1" = "dash-tx" ]; then
+  echo
+  exec gosu dash "$@"
+fi
+
+echo
+exec "$@"

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ A Dash Core docker image.
 
 ## Tags
 
-- `0.16.0.1`, `0.16`, `latest` ([0.16/Dockerfile](https://github.com/uphold/docker-dash-core/blob/master/0.16/Dockerfile))
+- `0.17.0.3`, `0.17`, `latest` ([0.17/Dockerfile](https://github.com/uphold/docker-dash-core/blob/master/0.17/Dockerfile))
+- `0.16.0.1`, `0.16` ([0.16/Dockerfile](https://github.com/uphold/docker-dash-core/blob/master/0.16/Dockerfile))
 - `0.15.0.0`, `0.15`  ([0.15/Dockerfile](https://github.com/uphold/docker-dash-core/blob/master/0.15/Dockerfile))
-- `0.14.0.5-alpine`, `0.14-alpine`, `alpine`, `latest` ([0.14/alpine/Dockerfile](https://github.com/uphold/docker-dash-core/blob/master/0.14/alpine/Dockerfile))
+- `0.14.0.5-alpine`, `0.14-alpine`, `alpine` ([0.14/alpine/Dockerfile](https://github.com/uphold/docker-dash-core/blob/master/0.14/alpine/Dockerfile))
 - `0.14.0.5`, `0.14`  ([0.14/Dockerfile](https://github.com/uphold/docker-dash-core/blob/master/0.14/Dockerfile))
 - `0.12.2.3-alpine`, `0.12-alpine` ([0.12/alpine/Dockerfile](https://github.com/uphold/docker-dash-core/blob/master/0.12/alpine/Dockerfile))
 - `0.12.2.3`, `0.12`  ([0.12/Dockerfile](https://github.com/uphold/docker-dash-core/blob/master/0.12/Dockerfile))


### PR DESCRIPTION
Bump latest to version [0.17.0.3](https://github.com/dashpay/dash/releases/tag/v0.17.0.3).
Create the necessary files for `Dash Core 0.17.0.3` in `./0.17`.