### PR TITLE
Bump dash-core 20

### DIFF
--- a/20/Dockerfile
+++ b/20/Dockerfile
@@ -28,8 +28,8 @@ RUN curl -o /usr/local/bin/gosu -fSL https://github.com/tianon/gosu/releases/dow
   && rm /usr/local/bin/gosu.asc \
   && chmod +x /usr/local/bin/gosu
 
-ENV DASH_VERSION=20.0.1
-ENV DASH_FOLDER_VERSION=20.0.1
+ENV DASH_VERSION=20.0.4
+ENV DASH_FOLDER_VERSION=20.0.4
 ENV DASH_DATA=/home/dash/.dashcore \
   PATH=/opt/dashcore-${DASH_FOLDER_VERSION}/bin:$PATH
 RUN curl -SLO https://github.com/dashpay/dash/releases/download/v${DASH_VERSION}/SHA256SUMS.asc \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Dash Core docker image.
 
 ## Tags
 
-- `20.0.1`, `20.0`, `20`, `latest` ([20/Dockerfile](https://github.com/uphold/docker-dash-core/blob/master/20/Dockerfile))
+- `20.0.4`, `20.0`, `20`, `latest` ([20/Dockerfile](https://github.com/uphold/docker-dash-core/blob/master/20/Dockerfile))
 - `19.2.0`, `19.2`, `19` ([19/Dockerfile](https://github.com/uphold/docker-dash-core/blob/master/19/Dockerfile))
 - `18.0.1`, `18.0`, `18` ([18/Dockerfile](https://github.com/uphold/docker-dash-core/blob/master/18/Dockerfile))
 - `0.17.0.3`, `0.17` ([0.17/Dockerfile](https://github.com/uphold/docker-dash-core/blob/master/0.17/Dockerfile))


### PR DESCRIPTION
Bumps dash-core 20 from 20.0.1 to 20.0.4

https://github.com/dashpay/dash/releases/tag/v20.0.4

